### PR TITLE
Allow pricing on all commands by not using any at the beginning of gnu-pricing.sh

### DIFF
--- a/bin/dirname
+++ b/bin/dirname
@@ -1,0 +1,1 @@
+../pricing.sh

--- a/bin/echo
+++ b/bin/echo
@@ -1,0 +1,1 @@
+../pricing.sh

--- a/bin/pwd
+++ b/bin/pwd
@@ -1,0 +1,1 @@
+../pricing.sh

--- a/bin/sed
+++ b/bin/sed
@@ -1,0 +1,1 @@
+../pricing.sh

--- a/pricing.sh
+++ b/pricing.sh
@@ -2,12 +2,13 @@
 
 #get this script's directory and command name
 pushd `dirname $0` > /dev/null
-THISDIR=`pwd`
+THISDIR=$PWD
 popd > /dev/null
 
 #remove the pricing directory from the path
 #(that way, the only commands that can't be priced are dirname, echo, and sed)
-PATH=`echo $PATH | sed "s@$THISDIR:@@"`
+PATH=${PATH//"$THISDIR:"/}
+PATH=${PATH//":$THISDIR"/}
 
 #set the variables needed for command and path shortcuts
 THISCMD=`basename "$0"`

--- a/pricing.sh
+++ b/pricing.sh
@@ -27,7 +27,6 @@ else
 fi
 
 #print pricing if requested
-ARGS="$@"
 for var in "$@"
 do
     if [ "$var" = "--pricing" ]
@@ -59,5 +58,5 @@ NEWCOUNT=$(( $USECOUNT + 1 ))
 echo "$NEWCOUNT" > "$HOME/.gnu-pricing/$THISCMD.usage"
 
 #run the command as normal
-$THISCMD $ARGS
+$THISCMD "$@"
 

--- a/pricing.sh
+++ b/pricing.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
 
+#IMPORTANT: do not use any GNU tools until further notice (see below)
+
 #get this script's directory and command name
-pushd `dirname $0` > /dev/null
+pushd ${0%/*} > /dev/null
 THISDIR=$PWD
 popd > /dev/null
 
 #remove the pricing directory from the path
-#(that way, the only commands that can't be priced are dirname, echo, and sed)
 PATH=${PATH//"$THISDIR:"/}
 PATH=${PATH//":$THISDIR"/}
+
+#IMPORTANT: GNU tools may be used after this line with no financial penalty
 
 #set the variables needed for command and path shortcuts
 THISCMD=`basename "$0"`


### PR DESCRIPTION
This PR replaces all use of expensive GNU tools at the beginning of `pricing.sh` (i.e. before `dirname $THISDIR`<sup>+$0.01</sup> has been removed from `$PATH`) with cost-effective bashisms. Then we can correctly charge for use of `echo`, `sed`, `dirname`, and `pwd`. Tested only with bash 4.2.37.
