### PR TITLE
better formatting of accrued costs

### DIFF
--- a/bin/gnu-pricing
+++ b/bin/gnu-pricing
@@ -17,8 +17,8 @@ USEDCMDS=`ls -1 "$HOME/.gnu-pricing/" | sed 's@.usage$@@'`
 #print header
 echo -e "Overall GNU command usage"
 echo -e ""
-echo -e "command\tusage\tcost"
-echo -e "-------\t-----\t----"
+echo -e " command   usage   cost"
+echo -e "--------- ------- ------"
 
 #get the usage count for each command
 for cmd in $USEDCMDS
@@ -28,13 +28,9 @@ do
 
     #calculate the cost for this command
     USECOST=$(( $THISCOUNT * 100 / 100 ))
-    if [ "${#USECOST}" = "1" ]
-    then
-        USECOST="0$USECOST"
-    fi
 
     #print the total usage and cost
-    echo -e "$cmd\t$THISCOUNT\t\$${USECOST::-2}.${USECOST:${#num}-2}"
+    printf "%9s %7d $%d.%02d\n" "$cmd" $THISCOUNT $(echo "$USECOST / 100" | bc) $(echo "$USECOST % 100" | bc)
 
     #add the usage for this command to the total usage
     TOTALCOUNT=$(( $TOTALCOUNT + $THISCOUNT ))
@@ -42,11 +38,7 @@ done
 
 #calculate the total cost
 TOTALCOST=$(( $TOTALCOUNT * 100 / 100 ))
-if [ "${#TOTALCOST}" = "1" ]
-then
-    TOTALCOST="0$TOTALCOST"
-fi
 
-echo -e "-------\t-----\t----"
-echo -e "Total\t$TOTALCOUNT\t\$${TOTALCOST::-2}.${TOTALCOST:${#num}-2}"
+echo -e "--------- ------- ------"
+printf "%9s %7d $%d.%02d\n" Total $TOTALCOUNT $(echo "$TOTALCOST / 100" | bc) $(echo "$TOTALCOST % 100" | bc)
 


### PR DESCRIPTION
Uses `printf`, fixed-width fields, and `bc` for a better-formatted table (why aren't we charged for use of `printf` and `bc`?). Not tested very heavily. Formatting will break when the total or individual count reaches 10^7.

Sample:

```
=======================
Welcome to GNU Pricing!
=======================

Using many GNU tools now cost $0.01 per use.

This command (gcc) has been used 6 times so far.

Overall GNU command usage
 command   usage   cost
--------- ------- ------
 basename      21 $0.21
      cat      48 $0.48
       cp       9 $0.09
  dirname       1 $0.01
     echo       7 $0.07
      gcc       6 $0.06
     grep     144 $1.44
       ln       7 $0.07
       ls      14 $0.14
    mkdir      27 $0.27
       mv      67 $0.67
      pwd       2 $0.02
       rm      78 $0.78
      sed      25 $0.25
    uname      28 $0.28
     uniq       3 $0.03
--------- ------- ------
    Total     487 $4.87

Please pay the total cost at https://donate.fsf.org/
```
