### PR TITLE
Fix stripped double quotes

### DIFF
--- a/pricing.sh
+++ b/pricing.sh
@@ -23,7 +23,6 @@ else
 fi
 
 #print pricing if requested
-ARGS="$@"
 for var in "$@"
 do
     if [ "$var" = "--pricing" ]
@@ -55,5 +54,5 @@ NEWCOUNT=$(( $USECOUNT + 1 ))
 echo "$NEWCOUNT" > "$HOME/.gnu-pricing/$THISCMD.usage"
 
 #run the command as normal
-$THISCMD $ARGS
+$THISCMD "$@"
 


### PR DESCRIPTION
If you are calling a program with some double quotes `"` within arguments, those get stripped.

Example:

```
$ /usr/bin/ls -l --time-style=+"%d.%m.%Y %H:%M"
total 0
-rw-r--r-- 1 geoffrey users 0 18.05.2015 20:33 bar
$ ls -l --time-style=+"%d.%m.%Y %H:%M"
ls: cannot access %H:%M: No such file or directory
ls: cannot access %H:%M: No such file or directory
$ ls -l --time-style=+"%d.%m.%Y %H:%M" .
ls: cannot access %H:%M: No such file or directory
ls: cannot access %H:%M: No such file or directory
.:
total 0
-rw-r--r-- 1 geoffrey users 0 18.05.2015 bar
```

This PR fixes this behaviour.
